### PR TITLE
Server/Fix2

### DIFF
--- a/server/routes/home.js
+++ b/server/routes/home.js
@@ -7,7 +7,7 @@ const pool2 = require('../modules/mysql2');
 
 /* ===== 홈페이지 데이터 처리 =====
  *
- * 홈페이지의 시각 데이터에 필요한 데이터를 반환합니다 (8월 1일부터 12월 15일까지)
+ * 홈페이지의 시각 데이터에 필요한 데이터를 반환합니다 (8월 1일부터 12월 31일까지)
  *
  * === client-input ===
  * NONE
@@ -90,8 +90,8 @@ router.post('/index', async function (req, res, next) {
         const byAge_vac2 = result13[0];
 
         // 데이터 가공
-        const date_ind = new Date("2021-08-01");
-        const date_last = new Date("2021-12-15");
+        let date_ind = new Date("2021-08-01");
+        const date_last = new Date("2021-12-31");
         const byMonth_cvac1 = []; // [{year: 연도, month: 월, count: 인원수}], 시간순으로 오름차순 정렬됨
         const byMonth_cvac2 = [];
         const byDay_cvac1 = []; // [{year: 연도, month: 월, day: 일, count: 인원수}], 시간순으로 오름차순 정렬됨
@@ -115,10 +115,40 @@ router.post('/index', async function (req, res, next) {
             } 
         }
 
-        while(date_ind <= date_last)
+        while(date_ind.getTime() <= date_last.getTime())
         {
             const year = date_ind.getFullYear();
-            const month = date_ind.getMonth();
+            const month = date_ind.getMonth() + 1;
+            const day = date_ind.getDate();
+
+            if(di1 < byDay_vac1.length)
+            {
+                if(byDay_vac1[di1].year == year && byDay_vac1[di1].month == month && byDay_vac1[di1].day == day)
+                {
+                    ds1 += byDay_vac1[di1].count;
+                    di1++;
+                }
+            }
+            if(di2 < byDay_vac2.length)
+            {
+                if(byDay_vac2[di2].year == year && byDay_vac2[di2].month == month && byDay_vac2[di2].day == day)
+                {
+                    ds2 += byDay_vac1[di2].count;
+                    di2++;
+                }
+            }
+
+            byDay_cvac1.push(new DC(year, month, day, ds1));
+            byDay_cvac2.push(new DC(year, month, day, ds2));
+
+            date_ind.setDate(date_ind.getDate() + 1);
+        }
+
+        date_ind = new Date("2021-08-01");
+        while(date_ind.getTime() <= date_last.getTime())
+        {
+            const year = date_ind.getFullYear();
+            const month = date_ind.getMonth() + 1;
             const day = date_ind.getDate();
 
             if(mi1 < byMonth_vac1.length)
@@ -137,29 +167,10 @@ router.post('/index', async function (req, res, next) {
                     mi2++;
                 }
             }
-            if(di1 < byDay_vac1.length)
-            {
-                if(byDay_vac1[di1].year == year && byDay_vac1[di1].month == month && byDay_vac1[di1].day == day)
-                {
-                    ds1 += byDay_vac1[di1].count;
-                    di1++;
-                }
-            }
-            if(di2 < byDay_vac2.length)
-            {
-                if(byDay_vac2[di2].year == year && byDay_vac2[di2].month == month && byDay_vac2[di2].day == day)
-                {
-                    ds2 += byDay_vac1[di2].count;
-                    di2++;
-                }
-            }
 
             byMonth_cvac1.push(new MC(year, month, ms1));
             byMonth_cvac2.push(new MC(year, month, ms2));
-            byDay_cvac1.push(new DC(year, month, day, ds1));
-            byDay_cvac2.push(new DC(year, month, day, ds2));
-
-            date_ind.setDate(date_ind.getDate() + 1);
+            date_ind.setMonth(date_ind.getMonth() + 1);
         }
 
         // 데이터 송신

--- a/server/routes/mypage.js
+++ b/server/routes/mypage.js
@@ -259,7 +259,7 @@ router.post('/getrev', async function (req, res, next) {
 });
 
 
-/* ===== 예약정보 수정 처리 =====
+/* ===== 예약정보 수정 처리 ===== (해당 페이지는 사용되지 않습니다 -> reservation/register와 통합됨)
  *
  * 1차, 2차 예약정보를 수정합니다
  *
@@ -273,7 +273,7 @@ router.post('/getrev', async function (req, res, next) {
  * ok = 예약 변경 성공시 true 반환
  *
 */
-router.post('/changerev', function (req, res, next) {
+/*router.post('/changerev', function (req, res, next) {
     var rev_num = req.body.rev_num;
     var rev_vac = req.body.rev_vac;
     var rev_hos = req.body.rev_hos;
@@ -298,7 +298,7 @@ router.post('/changerev', function (req, res, next) {
             connection.release();
         });
     });
-});
+});*/
 
 
 /* ===== 예약정보 취소 처리 =====

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -114,8 +114,26 @@ router.post('/more', async function (req, res, next) {
         const data1 = result1[0];
 
         var sql2;
-        if(isHos) sql2 = "select * from hospital_time where `Number`=?;";
-        else sql2 = "select * from pharmacy_time WHERE Pnumber=?";
+        if(isHos)
+        {
+            sql2 = "select h.Hnumber, ifnull(ht.Start_Mon, 900) as Start_Mon, ifnull(ht.Close_Mon, 1800) as Close_Mon, " + 
+                "ifnull(ht.Start_Tue, 900) as Start_Tue, ifnull(ht.Close_Tue, 1800) as Close_Tue, ifnull(ht.Start_Wed, 900) as Start_Wed, " + 
+                "ifnull(ht.Close_Wed, 1800) as Close_Wed, ifnull(ht.Start_Thu, 900) as Start_Thu, ifnull(ht.Close_Thu, 1800) as Close_Thu, " +
+                "ifnull(ht.Start_Fri, 900) as Start_Fri, ifnull(ht.Close_Fri, 1800) as Close_Fri, ifnull(ht.Start_Sat, 900) as Start_Sat, " +
+                "ifnull(ht.Close_Sat, 1300) as Close_Sat, ifnull(ht.Start_Sun, 1300) as Start_Sun, ifnull(ht.Close_Sun, 1300) as Close_Sun, " + 
+                "ifnull(ht.IsOpenHoliday, '휴진') as IsOpenHoliday, " +
+                "ifnull(ht.Lunch_Week, '12:00에서 13:00까지') as Lunch_Week from hospital as h left join hospital_time as ht on h.Hnumber = ht.Number"
+        }
+        else 
+        {
+            sql2 = "select h.Pnumber, ifnull(ht.Start_Mon, 900) as Start_Mon, ifnull(ht.Close_Mon, 1800) as Close_Mon, " + 
+                "ifnull(ht.Start_Tue, 900) as Start_Tue, ifnull(ht.Close_Tue, 1800) as Close_Tue, ifnull(ht.Start_Wed, 900) as Start_Wed, " + 
+                "ifnull(ht.Close_Wed, 1800) as Close_Wed, ifnull(ht.Start_Thu, 900) as Start_Thu, ifnull(ht.Close_Thu, 1800) as Close_Thu, " +
+                "ifnull(ht.Start_Fri, 900) as Start_Fri, ifnull(ht.Close_Fri, 1800) as Close_Fri, ifnull(ht.Start_Sat, 900) as Start_Sat, " +
+                "ifnull(ht.Close_Sat, 1300) as Close_Sat, ifnull(ht.Start_Sun, 1300) as Start_Sun, ifnull(ht.Close_Sun, 1300) as Close_Sun, " + 
+                "ifnull(ht.IsOpenHoliday, '휴진') as IsOpenHoliday, " +
+                "ifnull(ht.Lunch_Week, '12:00에서 13:00까지') as Lunch_Week from hospital as h left join pharmacy_time as ht on h.Pnumber = ht.Number"
+        }
         const result2 = await connection.query(sql2, [idx]);
         const data2 = result2[0];
 


### PR DESCRIPTION
2021/12/02 - Server/Fix2
- home/index: 누적 데이터가 정상적으로 표기되지 않던 문제 수정
일별 데이터 시간범위 변경 (2021년 8월 1일 ~ 2021년 12월 31일까지)
- mypage/changerev: 페이지 삭제 -> reservation/register와 통합
- reservation/register: 예약 수정 기능추가 -> 기존 예약 정보가 있으면 자동으로 수정이 됨
- reservation/search/:idx/:date, search/more: 병원/약국 운영시간(hospital_time, pharmacy_time)에서 DB에 데이터가 비어있으면 기본 데이터를 반환하도록 변경